### PR TITLE
Added nested fields

### DIFF
--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -25,7 +25,12 @@ export type Primitives =
   | ReturnType<typeof number>
   | ReturnType<typeof json>
   | ReturnType<typeof date>
-  | ReturnType<typeof blob>;
+  | ReturnType<typeof blob>
+  | NestedFields;
+
+export interface NestedFields {
+  [key: string]: Primitives;
+}
 
 export interface Model<Fields>
   extends Omit<RawModel, 'fields' | 'indexes' | 'triggers' | 'presets'> {
@@ -79,21 +84,23 @@ export interface SerializedLinkField
 // This type maps the fields of a model to their types.
 type FieldsToTypes<F> = F extends Record<string, Primitives>
   ? {
-      [K in keyof F]: F[K]['type'] extends 'string'
-        ? string
-        : F[K]['type'] extends 'number'
-          ? number
-          : F[K]['type'] extends 'boolean'
-            ? boolean
-            : F[K]['type'] extends 'link'
-              ? string
-              : F[K]['type'] extends 'json'
-                ? object
-                : F[K]['type'] extends 'blob'
-                  ? Blob
-                  : F[K]['type'] extends 'date'
-                    ? Date
-                    : never;
+      [K in keyof F]: F[K] extends Record<string, Primitives>
+        ? FieldsToTypes<F[K]>
+        : F[K]['type'] extends 'string'
+          ? string
+          : F[K]['type'] extends 'number'
+            ? number
+            : F[K]['type'] extends 'boolean'
+              ? boolean
+              : F[K]['type'] extends 'link'
+                ? string
+                : F[K]['type'] extends 'json'
+                  ? object
+                  : F[K]['type'] extends 'blob'
+                    ? Blob
+                    : F[K]['type'] extends 'date'
+                      ? Date
+                      : never;
     }
   : RoninFields;
 

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -616,4 +616,38 @@ describe('models', () => {
       ],
     });
   });
+
+  test('create model with nested fields', () => {
+    const Account = model({
+      slug: 'account',
+      pluralSlug: 'accounts',
+      fields: {
+        invoice: {
+          number: string({ required: true }),
+          date: date(),
+        },
+      },
+    });
+
+    expect(Account).toBeTypeOf('object');
+
+    expect(Account).toEqual({
+      // @ts-expect-error: The Account object has 'slug'.
+      slug: 'account',
+      pluralSlug: 'accounts',
+      fields: [
+        {
+          ...default_FIELD_PROPERTIES,
+          slug: 'invoice.number',
+          type: 'string',
+          required: true,
+        },
+        {
+          ...default_FIELD_PROPERTIES,
+          slug: 'invoice.date',
+          type: 'date',
+        },
+      ],
+    });
+  });
 });

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -644,7 +644,7 @@ describe('models', () => {
         },
         {
           ...default_FIELD_PROPERTIES,
-          slug: 'invoice.date',
+          slug: 'invoice.address',
           type: 'date',
         },
       ],

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -622,9 +622,9 @@ describe('models', () => {
       slug: 'account',
       pluralSlug: 'accounts',
       fields: {
-        invoice: {
-          number: string({ required: true }),
-          date: date(),
+        address: {
+          country: string({ required: true }),
+          city: string(),
         },
       },
     });
@@ -638,14 +638,14 @@ describe('models', () => {
       fields: [
         {
           ...default_FIELD_PROPERTIES,
-          slug: 'invoice.recipient',
+          slug: 'address.country',
           type: 'string',
           required: true,
         },
         {
           ...default_FIELD_PROPERTIES,
-          slug: 'invoice.address',
-          type: 'date',
+          slug: 'address.city',
+          type: 'string',
         },
       ],
     });

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -638,7 +638,7 @@ describe('models', () => {
       fields: [
         {
           ...default_FIELD_PROPERTIES,
-          slug: 'invoice.number',
+          slug: 'invoice.recipient',
           type: 'string',
           required: true,
         },


### PR DESCRIPTION
This PR allows to create nested fields like: 

```ts
const Account = model({
  slug: 'account',
  pluralSlug: 'accounts',
  fields: {
    invoice: {
      number: string({ required: true }),
      date: date(),
    },
  },
});
```

