### PR TITLE
Enforce error on defining `id` field

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,8 @@
 
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.yml"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,8 +25,5 @@
 
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.yml"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "biomejs.biome"
   }
 }

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1,4 +1,5 @@
 import type { blob, boolean, date, json, link, number, string } from '@/src/index';
+import { throwForbiddenModelDefinition } from '@/src/model/utils/errors';
 import {
   serializeFields,
   serializePresets,
@@ -116,7 +117,7 @@ type ForbiddenKeys =
   | 'ronin.locked';
 
 // Exclude forbidden keys.
-type RecordWithoutForbiddenKeys<V> = {
+export type RecordWithoutForbiddenKeys<V> = {
   [K in Exclude<string, ForbiddenKeys>]: V;
 } & {
   [K in ForbiddenKeys]?: never;
@@ -161,19 +162,7 @@ export const model = <Fields extends RecordWithoutForbiddenKeys<Primitives>>(
     triggers,
   } = model;
 
-  if (indexes && indexes.length > 0) {
-    for (const index of indexes) {
-      if (index.fields.length === 0) {
-        throw new Error('An index must have at least one field.');
-      }
-
-      for (const field of index.fields) {
-        if ('slug' in field && fields && fields[field.slug] === undefined) {
-          throw new Error(`The field ${field.slug} does not exist in this model.`);
-        }
-      }
-    }
-  }
+  throwForbiddenModelDefinition(model);
 
   return {
     slug,

--- a/src/model/utils/errors.ts
+++ b/src/model/utils/errors.ts
@@ -39,6 +39,21 @@ export class RoninError extends Error {
   }
 }
 
+/**
+ * Validates a model definition and throws errors for forbidden configurations.
+ *
+ * This function checks for:
+ * - Use of reserved field names (e.g. 'id')
+ * - Empty index definitions
+ * - References to undefined fields in indexes
+ *
+ * @param model - The model definition to validate
+ *
+ * @throws {RoninError} When validation fails with details about the specific issue:
+ *  - FIELD_RESERVED: When a reserved field name is used
+ *  - INDEX_NO_FIELDS: When an index is defined without any fields
+ *  - FIELD_NOT_DEFINED: When an index references a non-existent field
+ */
 export const throwForbiddenModelDefinition = <Fields>(model: Model<Fields>) => {
   const { fields, indexes, slug } = model;
 

--- a/src/model/utils/errors.ts
+++ b/src/model/utils/errors.ts
@@ -1,0 +1,80 @@
+import type { Model } from '@/src/model/model';
+
+type RoninErrorCode =
+  | 'FIELD_ALREADY_DEFINED'
+  | 'FIELD_NOT_DEFINED'
+  | 'INDEX_NO_FIELDS'
+  | 'FIELD_RESERVED';
+
+interface Issue {
+  message: string;
+  path: Array<string | number>;
+}
+
+interface Details {
+  message: string;
+  code: RoninErrorCode;
+  model: string;
+  field?: string;
+  fields?: Array<string>;
+  issues?: Array<Issue>;
+}
+
+export class RoninError extends Error {
+  code: Details['code'];
+  model?: Details['model'];
+  field?: Details['field'];
+  fields?: Details['fields'];
+  issues?: Details['issues'];
+
+  constructor(details: Details) {
+    super(details.message);
+
+    this.name = 'RoninError';
+    this.code = details.code;
+    this.model = details.model;
+    this.field = details.field;
+    this.fields = details.fields;
+    this.issues = details.issues;
+  }
+}
+
+export const throwForbiddenModelDefinition = <Fields>(model: Model<Fields>) => {
+  const { fields, indexes, slug } = model;
+
+  // Field validation
+  for (const [fieldSlug, _field] of Object.entries(fields ?? {})) {
+    if (fieldSlug === 'id') {
+      throw new RoninError({
+        message: 'The field "id" is reserved and cannot be used.',
+        code: 'FIELD_RESERVED',
+        model: slug,
+        field: 'id',
+      });
+    }
+  }
+
+  // Index validation
+  if (indexes && indexes.length > 0) {
+    for (const index of indexes) {
+      if (index.fields.length === 0) {
+        throw new RoninError({
+          message: 'An index must have at least one field.',
+          code: 'INDEX_NO_FIELDS',
+          model: slug,
+        });
+      }
+
+      for (const field of index.fields) {
+        if ('slug' in field && fields && fields[field.slug] === undefined) {
+          throw new RoninError({
+            message: `The field ${field.slug} does not exist in this model.`,
+            code: 'FIELD_NOT_DEFINED',
+            field: field.slug,
+            model: slug,
+          });
+        }
+      }
+    }
+  }
+};

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -650,4 +650,52 @@ describe('models', () => {
       ],
     });
   });
+
+  test('throws error when using reserved id field', () => {
+    expect(() =>
+      model({
+        slug: 'account',
+        pluralSlug: 'accounts',
+        fields: {
+          // @ts-expect-error: This is intended.
+          id: string(),
+        },
+      }),
+    ).toThrow('The field "id" is reserved and cannot be used.');
+  });
+
+  test('throws error when index has no fields', () => {
+    expect(() =>
+      model({
+        slug: 'account',
+        pluralSlug: 'accounts',
+        fields: {
+          name: string(),
+        },
+        indexes: [
+          {
+            fields: [],
+          },
+        ],
+      }),
+    ).toThrow('An index must have at least one field.');
+  });
+
+  test('throws error when index references non-existent field', () => {
+    expect(() =>
+      model({
+        slug: 'account',
+        pluralSlug: 'accounts',
+        fields: {
+          name: string(),
+        },
+        indexes: [
+          {
+            // @ts-expect-error: This is intended.
+            fields: [{ slug: 'email' }],
+          },
+        ],
+      }),
+    ).toThrow('The field email does not exist in this model.');
+  });
 });


### PR DESCRIPTION
Added `RoninError` to provide more meaningful error messages to users. Additionally, we now validate if a user attempts to define the `id` field and throw an error in such cases. While this is already flagged by the linter, it will now also cause a failure when running the schemas.